### PR TITLE
Add GifProvider to provide abstraction over the Giphy API [#11]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,25 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "es6": true
+    },
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "ecmaVersion": 2018,
+        "sourceType": "module"
+    },
+    "plugins": [
+        "react"
+    ],
+    "rules": {
+        "quotes": 2,
+        "arrow-parens": 2,
+        "semi": 2
+    }
+};

--- a/__mocks__/dataMocks.js
+++ b/__mocks__/dataMocks.js
@@ -1,20 +1,20 @@
 export const mockGifs = [
   {
     images: {
-      original: { url: 'image-url-0' },
-      fixed_width_small: { url: 'image-small-width-url-0' }
+      original: { url: "image-url-0" },
+      fixed_width_small: { url: "image-small-width-url-0" }
     }
   },
   {
     images: {
-      original: { url: 'image-url-1' },
-      fixed_width_small: { url: 'image-small-width-url-1' }
+      original: { url: "image-url-1" },
+      fixed_width_small: { url: "image-small-width-url-1" }
     }
   },
   {
     images: {
-      original: { url: 'image-url-2' },
-      fixed_width_small: { url: 'image-small-width-url-2' }
+      original: { url: "image-url-2" },
+      fixed_width_small: { url: "image-small-width-url-2" }
     }
   }
 ];

--- a/components/gifBox.js
+++ b/components/gifBox.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import Spinner from './spinner.js';
 import { isEmpty } from 'lodash';
-const giphy = require('giphy-api')('bH5Z69mu6KFkaxvRmNgi1kPtL02Cemin')
 import dotenv from 'dotenv';
 import GifList from './gifList.js';
+
+const GifProviderWrapper = require('../lib/GifProvider/GifProviderWrapper');
+const { getProviders } = require('../lib/GifProvider/GifProviderFactory');
+
+const gifProvider = new GifProviderWrapper(getProviders([ "giphy" ]));
 
 dotenv.config();
 
@@ -17,18 +21,18 @@ export default class GifBox extends React.Component {
 	}
 
 	componentDidMount() {
-		giphy.trending({ limit: 30 }).then((res) => {
+		gifProvider.trending({ limit: 30 }).then((res) => {
 			this.setState({ gifs: res.data });
 		})
 	}
 
 	searchGifs(query) {
 		if (query === '') {
-			giphy.trending({ limit: 30 }).then((res) => {
+			gifProvider.trending({ limit: 30 }).then((res) => {
 				this.setState({ gifs: res.data });
 			})
 		} else {
-			giphy.search({ q: query, limit: 30 }).then((res) => {
+			gifProvider.search({ q: query, limit: 30 }).then((res) => {
 				this.setState({ gifs: res.data })
 			});
 		}

--- a/components/gifBox.js
+++ b/components/gifBox.js
@@ -1,11 +1,11 @@
-import React from 'react';
-import Spinner from './spinner.js';
-import { isEmpty } from 'lodash';
-import dotenv from 'dotenv';
-import GifList from './gifList.js';
+import React from "react";
+import Spinner from "./spinner.js";
+import { isEmpty } from "lodash";
+import dotenv from "dotenv";
+import GifList from "./gifList.js";
 
-const GifProviderWrapper = require('../lib/GifProvider/GifProviderWrapper');
-const { getProviders } = require('../lib/GifProvider/GifProviderFactory');
+const GifProviderWrapper = require("../lib/GifProvider/GifProviderWrapper");
+const { getProviders } = require("../lib/GifProvider/GifProviderFactory");
 
 const gifProvider = new GifProviderWrapper(getProviders([ "giphy" ]));
 
@@ -21,19 +21,19 @@ export default class GifBox extends React.Component {
 	}
 
 	componentDidMount() {
-		gifProvider.trending({ limit: 30 }).then((res) => {
+		gifProvider.trending(30).then((res) => {
 			this.setState({ gifs: res.data });
-		})
+		});
 	}
 
 	searchGifs(query) {
-		if (query === '') {
-			gifProvider.trending({ limit: 30 }).then((res) => {
+		if (query === "") {
+			gifProvider.trending(30).then((res) => {
 				this.setState({ gifs: res.data });
-			})
+			});
 		} else {
-			gifProvider.search({ q: query, limit: 30 }).then((res) => {
-				this.setState({ gifs: res.data })
+			gifProvider.search(query, 30).then((res) => {
+				this.setState({ gifs: res.data });
 			});
 		}
 	}
@@ -41,9 +41,9 @@ export default class GifBox extends React.Component {
 	render() {
 		let content = null;
 		if (isEmpty(this.state.gifs)) {
-			content = <Spinner />
+			content = <Spinner />;
 		} else {
-			content = <GifList gifs={this.state.gifs} onSearch={this.searchGifs.bind(this)}/>
+			content = <GifList gifs={this.state.gifs} onSearch={this.searchGifs.bind(this)}/>;
 		}
 
 		return content;

--- a/components/gifBox.test.js
+++ b/components/gifBox.test.js
@@ -1,11 +1,11 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import GifBox from './gifBox';
-import { mockGifs } from '../__mocks__/dataMocks';
+import React from "react";
+import { shallow } from "enzyme";
+import GifBox from "./gifBox";
+import { mockGifs } from "../__mocks__/dataMocks";
 
-it('Renders Spinner or GifList according to gifs in the state', () => {
+it("Renders Spinner or GifList according to gifs in the state", () => {
   const wrapper = shallow(<GifBox />);
-  expect(wrapper.find('Spinner')).toHaveLength(1);
+  expect(wrapper.find("Spinner")).toHaveLength(1);
   wrapper.setState({ gifs: mockGifs });
-  expect(wrapper.find('GifList')).toHaveLength(1);
+  expect(wrapper.find("GifList")).toHaveLength(1);
 });

--- a/components/gifItem.js
+++ b/components/gifItem.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { CopyToClipboard } from 'react-copy-to-clipboard';
+import React from "react";
+import { CopyToClipboard } from "react-copy-to-clipboard";
 
 export default class GifItem extends React.Component {
 	constructor(props) {
@@ -11,12 +11,12 @@ export default class GifItem extends React.Component {
 
 		return (
 			<CopyToClipboard text={gif.images.original.url} onCopy={() => this.props.onGifClick(this.props.gifId)}>
-				<div className={ this.props.isCopied ? 'gif-item copied' : 'gif-item' }>
+				<div className={ this.props.isCopied ? "gif-item copied" : "gif-item" }>
 					<img className='gif' src={gif.images.fixed_width_small.url}/>
 					<div className="copy-indication">Copied!</div>
 					<div className="overlay"></div>
 				</div>
 			</CopyToClipboard>
-		)
+		);
 	}
 }

--- a/components/gifItem.test.js
+++ b/components/gifItem.test.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import GifItem from './gifItem';
-import { mockGifs } from '../__mocks__/dataMocks';
+import React from "react";
+import { shallow } from "enzyme";
+import GifItem from "./gifItem";
+import { mockGifs } from "../__mocks__/dataMocks";
 
 const mockGifId = 0;
 
@@ -20,15 +20,15 @@ beforeEach(() => {
   );
 });
 
-it('Calls method passed onGifClick with the gif id as argument', () => {
+it("Calls method passed onGifClick with the gif id as argument", () => {
   const wrapper = shallow(GifItemWrapper);
-  wrapper.find('CopyToClipboard').simulate('copy');
+  wrapper.find("CopyToClipboard").simulate("copy");
   expect(mockOnGifClick).toHaveBeenLastCalledWith(mockGifId);
 });
 
-it('Adds "copied" className to div when gif is copied', () => {
+it("Adds \"copied\" className to div when gif is copied", () => {
   const wrapper = shallow(GifItemWrapper);
-  expect(wrapper.find('div[className="gif-item"]')).toHaveLength(1);
+  expect(wrapper.find("div[className=\"gif-item\"]")).toHaveLength(1);
   wrapper.setProps({ isCopied: true });
-  expect(wrapper.find('div[className="gif-item copied"]')).toHaveLength(1);
+  expect(wrapper.find("div[className=\"gif-item copied\"]")).toHaveLength(1);
 });

--- a/components/gifList.js
+++ b/components/gifList.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import GifItem from './gifItem.js';
-import { map } from 'lodash';
+import React from "react";
+import GifItem from "./gifItem.js";
+import { map } from "lodash";
 
 const WAIT_INTERVAL = 1000;
 
@@ -11,7 +11,7 @@ export default class GifList extends React.Component {
 		this.handleChange = this.handleChange.bind(this);
 
 		this.state = {
-			value: '',
+			value: "",
 			typing: false,
 			typingTimeout: 0,
 			copied: null,
@@ -26,8 +26,8 @@ export default class GifList extends React.Component {
 		this.setState({
 			value: e.target.value,
 			typing: false,
-			typingTimeout: setTimeout(() => { this.triggerSearch() }, WAIT_INTERVAL),
-		})
+			typingTimeout: setTimeout(() => { this.triggerSearch(); }, WAIT_INTERVAL),
+		});
 	}
 
 	triggerSearch() {
@@ -37,13 +37,13 @@ export default class GifList extends React.Component {
 	}
 
 	handleKeyPress(e) {
-		if (e.key === 'Enter') {
+		if (e.key === "Enter") {
 			this.triggerSearch();
 		}
 	}
 
 	handleGifClick(gifId) {
-		this.setState({ copied: gifId })
+		this.setState({ copied: gifId });
 	}
 
 	render() {
@@ -51,7 +51,7 @@ export default class GifList extends React.Component {
 			return (
 				<GifItem gif={gif} key={index} gifId={index} onGifClick={(gifId) => this.handleGifClick(gifId)} isCopied={ this.state.copied === index }/>
 			);
-		})
+		});
 
 		return (
 			<div>

--- a/components/gifList.test.js
+++ b/components/gifList.test.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import GifList from './gifList';
-import { mockGifs } from '../__mocks__/dataMocks';
+import React from "react";
+import { shallow } from "enzyme";
+import GifList from "./gifList";
+import { mockGifs } from "../__mocks__/dataMocks";
 
 let GifListWrapper;
 let mockOnSearch;
@@ -14,7 +14,7 @@ beforeEach(() => {
 it("Copies gif on gif click", () => {
   const wrapper = shallow(GifListWrapper);
   expect(wrapper.instance().state.copied).toBeNull();
-  const gifItem = wrapper.find('GifItem').filterWhere(n => n.props().gifId === 0);
-  gifItem.simulate('gifClick', 0);
+  const gifItem = wrapper.find("GifItem").filterWhere((n) => n.props().gifId === 0);
+  gifItem.simulate("gifClick", 0);
   expect(wrapper.instance().state.copied).toBe(0);
 });

--- a/components/spinner.js
+++ b/components/spinner.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactLoading from 'react-loading';
+import React from "react";
+import ReactLoading from "react-loading";
 
 export default class Spinner extends React.Component {
 	render() {

--- a/components/spinner.test.js
+++ b/components/spinner.test.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import Spinner from './spinner';
+import React from "react";
+import { shallow } from "enzyme";
+import Spinner from "./spinner";
 
 it("renders without crashing", () => {
   shallow(<Spinner />);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-import menubar from 'menubar';
-import AutoLaunch from 'auto-launch';
-import { Menu } from 'electron';
+import menubar from "menubar";
+import AutoLaunch from "auto-launch";
+import { Menu } from "electron";
 
 export const mb = menubar({
     dir: __dirname,
@@ -8,18 +8,18 @@ export const mb = menubar({
     height: 330,
 	width: 440,
 	alwaysOnTop: false,
-	icon: __dirname + '/../assets/gif-icon.png'
+	icon: __dirname + "/../assets/gif-icon.png"
 });
 
-let appLauncher = new AutoLaunch({ name: 'GifBar', isHidden: true });
+let appLauncher = new AutoLaunch({ name: "GifBar", isHidden: true });
 
 const contextMenu = Menu.buildFromTemplate([
     {
-        label: 'Launch on Login',
-        type: 'checkbox',
+        label: "Launch on Login",
+        type: "checkbox",
         checked: false,
-        click: item => {
-            appLauncher.isEnabled().then(enabled => {
+        click: (item) => {
+            appLauncher.isEnabled().then((enabled) => {
                 if (enabled) {
                     return appLauncher.disable().then(() => {
                         item.checked = false;
@@ -33,19 +33,19 @@ const contextMenu = Menu.buildFromTemplate([
         },
     },
     {
-        label: `Quit GifBar`,
+        label: "Quit GifBar",
         click: () => mb.app.quit(),
 	},
 	{
-        label: 'Toggle DevTools',
-        accelerator: 'Alt+CommandOrControl+I',
-        click: function () { mb.window.toggleDevTools() }
+        label: "Toggle DevTools",
+        accelerator: "Alt+CommandOrControl+I",
+        click: function () { mb.window.toggleDevTools(); }
       }
 ]);
 
-mb.on('ready', () => {
-	console.log(`GifBar is Ready!!`);
-    mb.tray.on('right-click', () => {
+mb.on("ready", () => {
+	console.log("GifBar is Ready!!");
+    mb.tray.on("right-click", () => {
         mb.tray.popUpContextMenu(contextMenu);
     });
 });

--- a/lib/GifProvider/GifProvider.js
+++ b/lib/GifProvider/GifProvider.js
@@ -1,0 +1,25 @@
+/**
+ * @interface {GifProvider}
+ */
+module.exports = class GifProvider {
+
+    // This is an 'interface' to define what methods a GifProvider has.
+    //  Don't use this directly; instead, use one of the implementations.
+
+    /**
+     * @param limit {Number} (default: 30)
+     */
+    async trending(limit = 30) {
+        // do nothing
+        return Promise.resolve([]);
+    }
+
+    /**
+     * @param query {String} (default: '')
+     * @param limit {Number} (default: 30)
+     */
+    async search(query = '', limit = 30) {
+        // do nothing
+        return Promise.resolve([]);
+    }
+};

--- a/lib/GifProvider/GifProvider.js
+++ b/lib/GifProvider/GifProvider.js
@@ -18,7 +18,7 @@ module.exports = class GifProvider {
      * @param query {String} (default: '')
      * @param limit {Number} (default: 30)
      */
-    async search(query = '', limit = 30) {
+    async search(query = "", limit = 30) {
         // do nothing
         return Promise.resolve([]);
     }

--- a/lib/GifProvider/GifProvider.test.js
+++ b/lib/GifProvider/GifProvider.test.js
@@ -1,0 +1,16 @@
+const GifProvider = require('./GifProvider');
+
+it('Returns an empty array when .trending is called', async () => {
+    const gifProvider = new GifProvider();
+
+    expect(await gifProvider.trending()).toHaveLength(0);
+    expect(await gifProvider.trending(100)).toHaveLength(0);
+});
+
+it('Returns an empty array when .search is called', async () => {
+    const gifProvider = new GifProvider();
+
+    expect(await gifProvider.search()).toHaveLength(0);
+    expect(await gifProvider.search('')).toHaveLength(0);
+    expect(await gifProvider.search('', 10)).toHaveLength(0);
+});

--- a/lib/GifProvider/GifProvider.test.js
+++ b/lib/GifProvider/GifProvider.test.js
@@ -1,16 +1,16 @@
-const GifProvider = require('./GifProvider');
+const GifProvider = require("./GifProvider");
 
-it('Returns an empty array when .trending is called', async () => {
+it("Returns an empty array when .trending is called", async () => {
     const gifProvider = new GifProvider();
 
     expect(await gifProvider.trending()).toHaveLength(0);
     expect(await gifProvider.trending(100)).toHaveLength(0);
 });
 
-it('Returns an empty array when .search is called', async () => {
+it("Returns an empty array when .search is called", async () => {
     const gifProvider = new GifProvider();
 
     expect(await gifProvider.search()).toHaveLength(0);
-    expect(await gifProvider.search('')).toHaveLength(0);
-    expect(await gifProvider.search('', 10)).toHaveLength(0);
+    expect(await gifProvider.search("")).toHaveLength(0);
+    expect(await gifProvider.search("", 10)).toHaveLength(0);
 });

--- a/lib/GifProvider/GifProviderFactory.js
+++ b/lib/GifProvider/GifProviderFactory.js
@@ -1,8 +1,8 @@
-'use strict';
+"use strict";
 
-const { includes } = require('lodash');
+const { includes } = require("lodash");
 
-const providersList = require('./providers');
+const providersList = require("./providers");
 
 /**
  * Factory for GifProviders
@@ -15,7 +15,7 @@ module.exports = class GifProviderFactory {
      * @param sources {Array<String>}
      */
     static getProviders(sources = []) {
-        return providersList.filter( provider => includes(sources, provider.name) )
-            .map( provider => provider.class );
+        return providersList.filter( (provider) => includes(sources, provider.name) )
+            .map( (provider) => provider.class );
     }
 };

--- a/lib/GifProvider/GifProviderFactory.js
+++ b/lib/GifProvider/GifProviderFactory.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const { includes } = require('lodash');
+
+const providersList = require('./providers');
+
+/**
+ * Factory for GifProviders
+ * @class {GifProviderFactory}
+ */
+module.exports = class GifProviderFactory {
+
+    /**
+     * Takes an array of source names and returns an array of providers which match.
+     * @param sources {Array<String>}
+     */
+    static getProviders(sources = []) {
+        return providersList.filter( provider => includes(sources, provider.name) )
+            .map( provider => provider.class );
+    }
+};

--- a/lib/GifProvider/GifProviderFactory.test.js
+++ b/lib/GifProvider/GifProviderFactory.test.js
@@ -1,13 +1,13 @@
-const { getProviders } = require('./GifProviderFactory');
+const { getProviders } = require("./GifProviderFactory");
 
-it('Returns an empty array when .getProviders finds nothing', async () => {
+it("Returns an empty array when .getProviders finds nothing", async () => {
 
     expect(getProviders()).toHaveLength(0);
     expect(getProviders([])).toHaveLength(0);
     expect(getProviders([ "foo", "bar" ])).toHaveLength(0);
 });
 
-it('Returns an array of matching GifProviders when .getProviders finds a match', async () => {
+it("Returns an array of matching GifProviders when .getProviders finds a match", async () => {
 
     expect(getProviders([ "giphy" ])).toHaveLength(1);
     expect(getProviders([ "giphy", "baz" ])).toHaveLength(1);

--- a/lib/GifProvider/GifProviderFactory.test.js
+++ b/lib/GifProvider/GifProviderFactory.test.js
@@ -1,0 +1,14 @@
+const { getProviders } = require('./GifProviderFactory');
+
+it('Returns an empty array when .getProviders finds nothing', async () => {
+
+    expect(getProviders()).toHaveLength(0);
+    expect(getProviders([])).toHaveLength(0);
+    expect(getProviders([ "foo", "bar" ])).toHaveLength(0);
+});
+
+it('Returns an array of matching GifProviders when .getProviders finds a match', async () => {
+
+    expect(getProviders([ "giphy" ])).toHaveLength(1);
+    expect(getProviders([ "giphy", "baz" ])).toHaveLength(1);
+});

--- a/lib/GifProvider/GifProviderWrapper.js
+++ b/lib/GifProvider/GifProviderWrapper.js
@@ -1,9 +1,9 @@
-'use strict';
+"use strict";
 
-const Promise = require('bluebird');
-const { flatten } = require('lodash');
+const Promise = require("bluebird");
+const { flatten } = require("lodash");
 
-const GifProvider = require('./GifProvider');
+const GifProvider = require("./GifProvider");
 
 module.exports = class GifProviderWrapper extends GifProvider {
 
@@ -25,14 +25,14 @@ module.exports = class GifProviderWrapper extends GifProvider {
      * @param limit {Number} (default: 30)
      */
     async trending(limit = 30) {
-        return Promise.map(this.providers, provider => {
+        return Promise.map(this.providers, (provider) => {
             return provider.trending(limit)
                 // todo .then( format the response to something standard  )
                 //  only need to format once there's multiple providers implemented
                 //  lets format to match the giphy response as that's already expected elsewhere
                 .catch( () => [] );
         } )
-            .then( results => flatten(results) );
+            .then( (results) => flatten(results) );
     }
 
     /**
@@ -43,14 +43,14 @@ module.exports = class GifProviderWrapper extends GifProvider {
      * @param limit {Number} (default: 30)
      */
     async search(query, limit = 30) {
-        return Promise.map(this.providers, provider => {
+        return Promise.map(this.providers, (provider) => {
             return provider.search(query, limit)
                 // todo .then( format the response to something standard  )
                 //  only need to format once there's multiple providers implemented
                 //  lets format to match the giphy response as that's already expected elsewhere
                 .catch( () => [] )
-                .then( results => flatten(results) );
+                .then( (results) => flatten(results) );
         } )
-            .then( results => flatten(results) );
+            .then( (results) => flatten(results) );
     }
 };

--- a/lib/GifProvider/GifProviderWrapper.js
+++ b/lib/GifProvider/GifProviderWrapper.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const Promise = require('bluebird');
+const { flatten } = require('lodash');
+
+const GifProvider = require('./GifProvider');
+
+module.exports = class GifProviderWrapper extends GifProvider {
+
+    /**
+     * Create a new provider wrapper.
+     * The order the providers are given will denote their order in search results.
+     * @param providers {Array<GifProvider>}
+     */
+    constructor(providers = []) {
+        super();
+
+        this.providers = providers;
+    }
+
+    /**
+     * Get a list of trending gifs from all wrapped providers.
+     * (Returns an empty list if no wrapped API support trending gifs, or all return empty lists)
+     *
+     * @param limit {Number} (default: 30)
+     */
+    async trending(limit = 30) {
+        return Promise.map(this.providers, provider => {
+            return provider.trending(limit)
+                // todo .then( format the response to something standard  )
+                //  only need to format once there's multiple providers implemented
+                //  lets format to match the giphy response as that's already expected elsewhere
+                .catch( () => [] );
+        } )
+            .then( results => flatten(results) );
+    }
+
+    /**
+     * Search for gifs that match the query string from all wrapped providers.
+     * (Returns an empty list if there are no matching results from any wrapped API.)
+     *
+     * @param query {String}
+     * @param limit {Number} (default: 30)
+     */
+    async search(query, limit = 30) {
+        return Promise.map(this.providers, provider => {
+            return provider.search(query, limit)
+                // todo .then( format the response to something standard  )
+                //  only need to format once there's multiple providers implemented
+                //  lets format to match the giphy response as that's already expected elsewhere
+                .catch( () => [] )
+                .then( results => flatten(results) );
+        } )
+            .then( results => flatten(results) );
+    }
+};

--- a/lib/GifProvider/GifProviderWrapper.test.js
+++ b/lib/GifProvider/GifProviderWrapper.test.js
@@ -1,29 +1,29 @@
-const GifProviderWrapper = require('./GifProviderWrapper');
-const GifProvider = require('./GifProvider');
+const GifProviderWrapper = require("./GifProviderWrapper");
+const GifProvider = require("./GifProvider");
 
 // tests for having an empty providers list
 
-it('Can be instantiated with an empty \'providers\' list', async () => {
+it("Can be instantiated with an empty 'providers' list", async () => {
 
     expect( () => new GifProviderWrapper() ).not.toThrow();
     expect( () => new GifProviderWrapper([]) ).not.toThrow();
 });
 
-it('Returns an empty array when .trending is called if instantiated with an empty \'providers\' list', async () => {
+it("Returns an empty array when .trending is called if instantiated with an empty 'providers' list", async () => {
     const gifProviderWrapper = new GifProviderWrapper();
 
     expect(await gifProviderWrapper.trending()).toHaveLength(0);
 });
 
-it('Returns an empty array when .search is called if instantiated with an empty \'providers\' list', async () => {
+it("Returns an empty array when .search is called if instantiated with an empty 'providers' list", async () => {
     const gifProviderWrapper = new GifProviderWrapper();
 
-    expect(await gifProviderWrapper.search('funny')).toHaveLength(0);
+    expect(await gifProviderWrapper.search("funny")).toHaveLength(0);
 });
 
 // tests for having one or more providers
 
-it('Can be instantiated with a non-empty \'providers\' list', async () => {
+it("Can be instantiated with a non-empty 'providers' list", async () => {
     const gifProvider = new GifProvider();
     const gifProvider2 = new GifProvider();
 
@@ -31,15 +31,15 @@ it('Can be instantiated with a non-empty \'providers\' list', async () => {
     expect( () => new GifProviderWrapper([ gifProvider, gifProvider2 ]) ).not.toThrow();
 });
 
-it('Returns a flattened array of the wrapped providers\' results when .trending is called', async () => {
+it("Returns a flattened array of the wrapped providers' results when .trending is called", async () => {
     const mockGifProvider = new class {
-        trending() { return Promise.resolve([ "foo", "bar", "bing" ]) }
+        trending() { return Promise.resolve([ "foo", "bar", "bing" ]); }
     };
     const mockGifProvider2 = new class {
-        trending() { return Promise.resolve([ "dee", "goo", "naa" ]) }
+        trending() { return Promise.resolve([ "dee", "goo", "naa" ]); }
     };
     const mockGifProvider3 = new class {
-        trending() { return Promise.reject() }
+        trending() { return Promise.reject(); }
     };
     const gifProviderWrapper = new GifProviderWrapper([ mockGifProvider ]);
     const gifProviderWrapper2 = new GifProviderWrapper([ mockGifProvider, mockGifProvider2 ]);
@@ -50,15 +50,15 @@ it('Returns a flattened array of the wrapped providers\' results when .trending 
     expect(await gifProviderWrapper3.trending()).toHaveLength(3);
 });
 
-it('Returns a flattened array of the wrapped providers\' results when .search is called', async () => {
+it("Returns a flattened array of the wrapped providers' results when .search is called", async () => {
     const mockGifProvider = new class {
-        search() { return Promise.resolve([ "foo", "bar", "bing" ]) }
+        search() { return Promise.resolve([ "foo", "bar", "bing" ]); }
     };
     const mockGifProvider2 = new class {
-        search() { return Promise.resolve([ "dee", "goo", "naa" ]) }
+        search() { return Promise.resolve([ "dee", "goo", "naa" ]); }
     };
     const mockGifProvider3 = new class {
-        search() { return Promise.reject() }
+        search() { return Promise.reject(); }
     };
     const gifProviderWrapper = new GifProviderWrapper([ mockGifProvider ]);
     const gifProviderWrapper2 = new GifProviderWrapper([ mockGifProvider, mockGifProvider2 ]);

--- a/lib/GifProvider/GifProviderWrapper.test.js
+++ b/lib/GifProvider/GifProviderWrapper.test.js
@@ -1,0 +1,70 @@
+const GifProviderWrapper = require('./GifProviderWrapper');
+const GifProvider = require('./GifProvider');
+
+// tests for having an empty providers list
+
+it('Can be instantiated with an empty \'providers\' list', async () => {
+
+    expect( () => new GifProviderWrapper() ).not.toThrow();
+    expect( () => new GifProviderWrapper([]) ).not.toThrow();
+});
+
+it('Returns an empty array when .trending is called if instantiated with an empty \'providers\' list', async () => {
+    const gifProviderWrapper = new GifProviderWrapper();
+
+    expect(await gifProviderWrapper.trending()).toHaveLength(0);
+});
+
+it('Returns an empty array when .search is called if instantiated with an empty \'providers\' list', async () => {
+    const gifProviderWrapper = new GifProviderWrapper();
+
+    expect(await gifProviderWrapper.search('funny')).toHaveLength(0);
+});
+
+// tests for having one or more providers
+
+it('Can be instantiated with a non-empty \'providers\' list', async () => {
+    const gifProvider = new GifProvider();
+    const gifProvider2 = new GifProvider();
+
+    expect( () => new GifProviderWrapper([ gifProvider ]) ).not.toThrow();
+    expect( () => new GifProviderWrapper([ gifProvider, gifProvider2 ]) ).not.toThrow();
+});
+
+it('Returns a flattened array of the wrapped providers\' results when .trending is called', async () => {
+    const mockGifProvider = new class {
+        trending() { return Promise.resolve([ "foo", "bar", "bing" ]) }
+    };
+    const mockGifProvider2 = new class {
+        trending() { return Promise.resolve([ "dee", "goo", "naa" ]) }
+    };
+    const mockGifProvider3 = new class {
+        trending() { return Promise.reject() }
+    };
+    const gifProviderWrapper = new GifProviderWrapper([ mockGifProvider ]);
+    const gifProviderWrapper2 = new GifProviderWrapper([ mockGifProvider, mockGifProvider2 ]);
+    const gifProviderWrapper3 = new GifProviderWrapper([ mockGifProvider, mockGifProvider3 ]);
+
+    expect(await gifProviderWrapper.trending()).toHaveLength(3);
+    expect(await gifProviderWrapper2.trending()).toHaveLength(6);
+    expect(await gifProviderWrapper3.trending()).toHaveLength(3);
+});
+
+it('Returns a flattened array of the wrapped providers\' results when .search is called', async () => {
+    const mockGifProvider = new class {
+        search() { return Promise.resolve([ "foo", "bar", "bing" ]) }
+    };
+    const mockGifProvider2 = new class {
+        search() { return Promise.resolve([ "dee", "goo", "naa" ]) }
+    };
+    const mockGifProvider3 = new class {
+        search() { return Promise.reject() }
+    };
+    const gifProviderWrapper = new GifProviderWrapper([ mockGifProvider ]);
+    const gifProviderWrapper2 = new GifProviderWrapper([ mockGifProvider, mockGifProvider2 ]);
+    const gifProviderWrapper3 = new GifProviderWrapper([ mockGifProvider, mockGifProvider3 ]);
+
+    expect(await gifProviderWrapper.search()).toHaveLength(3);
+    expect(await gifProviderWrapper2.search()).toHaveLength(6);
+    expect(await gifProviderWrapper3.search()).toHaveLength(3);
+});

--- a/lib/GifProvider/providers/GiphyGifProvider.js
+++ b/lib/GifProvider/providers/GiphyGifProvider.js
@@ -1,8 +1,8 @@
-'use strict';
+"use strict";
 
-const giphy = require('giphy-api');
+const giphy = require("giphy-api");
 
-const GifProvider = require('../GifProvider');
+const GifProvider = require("../GifProvider");
 
 /**
  * GifProvider for the Giphy API
@@ -22,7 +22,7 @@ module.exports = class GiphyGifProvider extends GifProvider {
      * @param limit {Number} (default: 30)
      */
     async trending(limit = 30) {
-        return this.api.trending({ 'limit':limit });
+        return this.api.trending({ "limit":limit });
     }
 
     /**
@@ -33,7 +33,7 @@ module.exports = class GiphyGifProvider extends GifProvider {
      * @param limit {Number} (default: 30)
      */
     async search(query, limit = 30) {
-        return this.api.search({'q': query, 'limit': limit});
+        return this.api.search({"q": query, "limit": limit});
     }
 
 };

--- a/lib/GifProvider/providers/GiphyGifProvider.js
+++ b/lib/GifProvider/providers/GiphyGifProvider.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const giphy = require('giphy-api');
+
+const GifProvider = require('../GifProvider');
+
+/**
+ * GifProvider for the Giphy API
+ * @class {GiphyGifProvider}
+ */
+module.exports = class GiphyGifProvider extends GifProvider {
+
+    constructor(apiKey) {
+        super();
+
+        this.api = giphy(apiKey);
+    }
+
+    /**
+     * Get a list of trending gifs from the Giphy API.
+     *
+     * @param limit {Number} (default: 30)
+     */
+    async trending(limit = 30) {
+        return this.api.trending({ 'limit':limit });
+    }
+
+    /**
+     * Search for gifs from the Giphy API that match the query string
+     * (Returns an empty list if there are no matching results.)
+     *
+     * @param query {String}
+     * @param limit {Number} (default: 30)
+     */
+    async search(query, limit = 30) {
+        return this.api.search({'q': query, 'limit': limit});
+    }
+
+};

--- a/lib/GifProvider/providers/index.js
+++ b/lib/GifProvider/providers/index.js
@@ -1,10 +1,10 @@
 // Add each provider here to have it discovered by the factory
 
 // 1. Import the class
-const GiphyGifProvider = require('./GiphyGifProvider');
+const GiphyGifProvider = require("./GiphyGifProvider");
 
 module.exports = [
 
     // 2. Add an entry; include a name and an instance
-    { name: 'giphy', class: new GiphyGifProvider('bH5Z69mu6KFkaxvRmNgi1kPtL02Cemin') }, // todo move ApiKey to pipeline
+    { name: "giphy", class: new GiphyGifProvider("bH5Z69mu6KFkaxvRmNgi1kPtL02Cemin") }, // todo move ApiKey to pipeline
 ];

--- a/lib/GifProvider/providers/index.js
+++ b/lib/GifProvider/providers/index.js
@@ -1,0 +1,10 @@
+// Add each provider here to have it discovered by the factory
+
+// 1. Import the class
+const GiphyGifProvider = require('./GiphyGifProvider');
+
+module.exports = [
+
+    // 2. Add an entry; include a name and an instance
+    { name: 'giphy', class: new GiphyGifProvider('bH5Z69mu6KFkaxvRmNgi1kPtL02Cemin') }, // todo move ApiKey to pipeline
+];

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { render } from 'react-dom';
-import GifBox from './components/gifBox.js'
+import React from "react";
+import { render } from "react-dom";
+import GifBox from "./components/gifBox.js";
 
-render(<GifBox />, document.getElementById('main'));
+render(<GifBox />, document.getElementById("main"));

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "jest": {
         "setupTestFrameworkScriptFile": "<rootDir>setupTests.js",
         "collectCoverageFrom": [
-            "components/**/*.{js,jsx}"
+            "components/**/*.{js,jsx}",
+            "lib/**/*.{js,jsx}"
         ]
     },
     "keywords": [
@@ -40,6 +41,7 @@
     },
     "dependencies": {
         "auto-launch": "^5.0.5",
+        "bluebird": "^3.7.1",
         "concurrently": "4.1.0",
         "dotenv": "^8.2.0",
         "electron-debug": "2.0.0",
@@ -79,6 +81,7 @@
         },
         "files": [
             "dist/**/*",
+            "lib/**/*",
             "node_modules/**/*",
             "assets/*"
         ]

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
         "electron-packager": "^14.0.6",
         "enzyme": "^3.6.0",
         "enzyme-adapter-react-16": "^1.5.0",
+        "eslint": "^6.5.1",
+        "eslint-plugin-react": "^7.16.0",
         "jest": "^23.6.0",
         "parcel-bundler": "^1.9.6",
         "prettier": "^1.13.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
         "package": "electron-packager . GifBar --platform=darwin --icon=icon.icns --overwrite --out=GifBarApp",
         "package-dmg": "electron-installer-dmg ./GifBarApp/GifBar-darwin-x64/GifBar.app GifBar --icon=icon.icns --overwrite --out=GifBarInstaller",
         "test": "jest --env=jsdom --coverage --colors",
-        "test:watch": "jest --env=jsdom --colors --watchAll"
+        "test:watch": "jest --env=jsdom --colors --watchAll",
+        "lint": "./node_modules/.bin/eslint .",
+        "lint-fix": "./node_modules/.bin/eslint . --fix"
     },
     "jest": {
         "setupTestFrameworkScriptFile": "<rootDir>setupTests.js",

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,4 +1,4 @@
-import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
 
 Enzyme.configure({ adapter: new Adapter() });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,13 @@
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-4.1.0.tgz#33eff662a5c39c0c2061170cc003c5120743fff0"
 
+"@babel/code-frame@^7.0.0":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
+  integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
 "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
@@ -83,6 +90,11 @@ acorn-globals@^4.1.0:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
+acorn-jsx@^5.0.2:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
+  integrity sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==
+
 acorn-walk@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.0.tgz#c957f4a1460da46af4a0388ce28b4c99355b0cbc"
@@ -99,6 +111,11 @@ acorn@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.2.tgz#6a459041c320ab17592c6317abbfdf4bbaa98ca4"
 
+acorn@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
+  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
+
 ajv-keywords@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.0.tgz#4b831e7b531415a7cc518cd404e73f6193c6349d"
@@ -112,6 +129,16 @@ ajv@^5.1.0, ajv@^5.3.0:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
+
+ajv@^6.10.0, ajv@^6.10.2:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
+  integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 ajv@^6.9.2:
   version "6.10.0"
@@ -137,6 +164,11 @@ ansi-align@^3.0.0:
 ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
+
+ansi-escapes@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
+  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -261,6 +293,14 @@ array-equal@^1.0.0:
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
+
+array-includes@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
+  integrity sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
 
 array-unique@^0.2.1:
   version "0.2.1"
@@ -1339,6 +1379,11 @@ callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
 
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -1434,6 +1479,11 @@ chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
@@ -1517,6 +1567,11 @@ cli-cursor@^2.1.0:
 cli-spinners@^1.1.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
+
+cli-width@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
+  integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
 cliui@^4.0.0:
   version "4.1.0"
@@ -1850,7 +1905,7 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.0, cross-spawn@^6.0.4:
+cross-spawn@^6.0.0, cross-spawn@^6.0.4, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   dependencies:
@@ -2204,6 +2259,13 @@ define-properties@^1.1.2:
     foreach "^2.0.5"
     object-keys "^1.0.8"
 
+define-properties@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
+
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
@@ -2302,6 +2364,20 @@ dmg-builder@6.6.4:
     js-yaml "^3.13.1"
     parse-color "^1.0.0"
     sanitize-filename "^1.6.1"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
 
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
@@ -2686,6 +2762,22 @@ es-abstract@^1.10.0, es-abstract@^1.5.0, es-abstract@^1.5.1, es-abstract@^1.6.1:
     is-callable "^1.1.3"
     is-regex "^1.0.4"
 
+es-abstract@^1.12.0, es-abstract@^1.15.0, es-abstract@^1.7.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.15.0.tgz#8884928ec7e40a79e3c9bc812d37d10c8b24cc57"
+  integrity sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==
+  dependencies:
+    es-to-primitive "^1.2.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.0"
+    is-callable "^1.1.4"
+    is-regex "^1.0.4"
+    object-inspect "^1.6.0"
+    object-keys "^1.1.1"
+    string.prototype.trimleft "^2.1.0"
+    string.prototype.trimright "^2.1.0"
+
 es-to-primitive@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
@@ -2693,6 +2785,15 @@ es-to-primitive@^1.1.1:
     is-callable "^1.1.1"
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
+
+es-to-primitive@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -2724,6 +2825,93 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-plugin-react@^7.16.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz#9928e4f3e2122ed3ba6a5b56d0303ba3e41d8c09"
+  integrity sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==
+  dependencies:
+    array-includes "^3.0.3"
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.2.1"
+    object.entries "^1.1.0"
+    object.fromentries "^2.0.0"
+    object.values "^1.1.0"
+    prop-types "^15.7.2"
+    resolve "^1.12.0"
+
+eslint-scope@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
+  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-utils@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
+  integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
+  dependencies:
+    eslint-visitor-keys "^1.0.0"
+
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
+  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
+
+eslint@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.5.1.tgz#828e4c469697d43bb586144be152198b91e96ed6"
+  integrity sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.10.0"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^1.4.2"
+    eslint-visitor-keys "^1.1.0"
+    espree "^6.1.1"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.0.0"
+    globals "^11.7.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^6.4.1"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.14"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^6.1.2"
+    strip-ansi "^5.2.0"
+    strip-json-comments "^3.0.1"
+    table "^5.2.3"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
+espree@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.1.1.tgz#7f80e5f7257fc47db450022d723e356daeb1e5de"
+  integrity sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==
+  dependencies:
+    acorn "^7.0.0"
+    acorn-jsx "^5.0.2"
+    eslint-visitor-keys "^1.1.0"
+
 esprima@^2.6.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
@@ -2735,6 +2923,25 @@ esprima@^3.1.3:
 esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
+esquery@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
+  integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==
+  dependencies:
+    estraverse "^4.0.0"
+
+esrecurse@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
+  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
+  dependencies:
+    estraverse "^4.1.0"
+
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
+  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 estraverse@^4.2.0:
   version "4.2.0"
@@ -2854,6 +3061,15 @@ extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
+external-editor@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
+  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -2938,6 +3154,20 @@ fd-slicer@~1.0.1:
   dependencies:
     pend "~1.2.0"
 
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+  dependencies:
+    flat-cache "^2.0.1"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -2990,6 +3220,20 @@ find-up@^3.0.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
   dependencies:
     locate-path "^3.0.0"
+
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+  dependencies:
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
+flatted@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
+  integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
 flatten@^1.0.2:
   version "1.0.2"
@@ -3145,6 +3389,11 @@ function.prototype.name@^1.1.0:
     function-bind "^1.1.1"
     is-callable "^1.1.3"
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
 galactus@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/galactus/-/galactus-0.2.1.tgz#cbed2d20a40c1f5679a35908e2b9415733e78db9"
@@ -3259,6 +3508,13 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
+glob-parent@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
+  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
@@ -3302,6 +3558,11 @@ global-dirs@^0.1.0:
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
   dependencies:
     ini "^1.3.4"
+
+globals@^11.7.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^9.18.0:
   version "9.18.0"
@@ -3618,6 +3879,19 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+import-fresh@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.1.0.tgz#6d33fa1dcef6df930fae003446f33415af905118"
+  integrity sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
 import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
@@ -3665,6 +3939,25 @@ inherits@2.0.1:
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+
+inquirer@^6.4.1:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.2.tgz#ad50942375d036d327ff528c08bd5fab089928ca"
+  integrity sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^2.0.0"
+    lodash "^4.17.12"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.4.0"
+    string-width "^2.1.0"
+    strip-ansi "^5.1.0"
+    through "^2.3.6"
 
 invariant@^2.2.2:
   version "2.2.3"
@@ -3865,6 +4158,13 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-glob@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
 is-installed-globally@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
@@ -3931,6 +4231,11 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
+
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
@@ -3968,6 +4273,13 @@ is-svg@^3.0.0:
 is-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
+
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
+  dependencies:
+    has-symbols "^1.0.0"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -4413,7 +4725,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-tokens@^4.0.0:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
@@ -4517,6 +4829,11 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
 json-stringify-safe@~5.0.0, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -4552,6 +4869,14 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jsx-ast-utils@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz#4d4973ebf8b9d2837ee91a8208cc66f3a2776cfb"
+  integrity sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==
+  dependencies:
+    array-includes "^3.0.3"
+    object.assign "^4.1.0"
 
 junk@^3.1.0:
   version "3.1.0"
@@ -4629,7 +4954,7 @@ leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
 
-levn@~0.3.0:
+levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   dependencies:
@@ -4711,7 +5036,7 @@ lodash@4.17.11, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
-lodash@^4.17.11:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -4731,6 +5056,13 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -5053,6 +5385,11 @@ ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
+
 nan@^2.0.7, nan@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
@@ -5335,6 +5672,11 @@ object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
 
+object-keys@^1.0.12, object-keys@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
 object-keys@^1.0.6:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
@@ -5367,6 +5709,26 @@ object.entries@^1.0.4:
     function-bind "^1.1.0"
     has "^1.0.1"
 
+object.entries@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.0.tgz#2024fc6d6ba246aee38bdb0ffd5cfbcf371b7519"
+  integrity sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.12.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+
+object.fromentries@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.1.tgz#050f077855c7af8ae6649f45c80b16ee2d31e704"
+  integrity sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.15.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
@@ -5395,6 +5757,16 @@ object.values@^1.0.4:
     es-abstract "^1.6.1"
     function-bind "^1.1.0"
     has "^1.0.1"
+
+object.values@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.0.tgz#bf6810ef5da3e5325790eaaa2be213ea84624da9"
+  integrity sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.12.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -5427,7 +5799,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -5474,7 +5846,7 @@ os-locale@^3.1.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -5610,6 +5982,13 @@ parcel-bundler@^1.9.6:
     tomlify-j0.4 "^3.0.0"
     v8-compile-cache "^2.0.0"
     ws "^5.1.1"
+
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
 
 parse-asn1@^5.0.0:
   version "5.1.0"
@@ -6320,6 +6699,11 @@ progress-stream@^1.1.0:
     speedometer "~0.1.2"
     through2 "~0.2.3"
 
+progress@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 prompts@^0.1.9:
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.14.tgz#a8e15c612c5c9ec8f8111847df3337c9cbd443b2"
@@ -6333,6 +6717,15 @@ prop-types@^15.5.8, prop-types@^15.6.2:
   dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -6498,6 +6891,11 @@ react-dom@16.8.3:
 react-is@^16.4.2, react-is@^16.5.2:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"
+
+react-is@^16.8.1:
+  version "16.10.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.2.tgz#984120fd4d16800e9a738208ab1fba422d23b5ab"
+  integrity sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==
 
 react-loading@2.0.3:
   version "2.0.3"
@@ -6682,6 +7080,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regexpp@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
@@ -6842,6 +7245,11 @@ resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -6856,7 +7264,7 @@ resolve@^1.1.5, resolve@^1.4.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.1.6:
+resolve@^1.1.6, resolve@^1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
@@ -6896,6 +7304,13 @@ rgba-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
 
+rimraf@2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
@@ -6934,6 +7349,13 @@ rsvp@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
 
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
+  dependencies:
+    is-promise "^2.1.0"
+
 rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
@@ -6941,6 +7363,13 @@ rx@^4.1.0:
 rxjs@^6.3.3:
   version "6.3.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.4.0:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
+  integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==
   dependencies:
     tslib "^1.9.0"
 
@@ -7028,7 +7457,7 @@ semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
-semver@^6.0.0:
+semver@^6.0.0, semver@^6.1.2:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -7158,6 +7587,15 @@ sisteransi@^0.1.1:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slice-ansi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
+  dependencies:
+    ansi-styles "^3.2.0"
+    astral-regex "^1.0.0"
+    is-fullwidth-code-point "^2.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -7391,7 +7829,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0, string-width@^2.1.1:
+string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -7414,6 +7852,22 @@ string.prototype.trim@^1.1.2:
     define-properties "^1.1.2"
     es-abstract "^1.5.0"
     function-bind "^1.0.2"
+
+string.prototype.trimleft@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz#6cc47f0d7eb8d62b0f3701611715a3954591d634"
+  integrity sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==
+  dependencies:
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
+
+string.prototype.trimright@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz#669d164be9df9b6f7559fa8e89945b168a5a6c58"
+  integrity sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==
+  dependencies:
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
 
 string_decoder@^1.0.0:
   version "1.1.0"
@@ -7484,6 +7938,11 @@ strip-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
+
+strip-json-comments@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
+  integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -7573,6 +8032,16 @@ symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
+table@^5.2.3:
+  version "5.4.6"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
+  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
+  dependencies:
+    ajv "^6.10.2"
+    lodash "^4.17.14"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
+
 tar@^4:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.4.tgz#ec8409fae9f665a4355cc3b4087d0820232bb8cd"
@@ -7617,6 +8086,11 @@ test-exclude@^4.2.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+text-table@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
 throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
@@ -7638,6 +8112,11 @@ through2@~0.2.3:
   dependencies:
     readable-stream "~1.1.9"
     xtend "~2.1.1"
+
+through@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 timers-browserify@^2.0.4:
   version "2.0.6"
@@ -7679,6 +8158,13 @@ tmp@0.1.0:
   integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
   dependencies:
     rimraf "^2.6.3"
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -7979,6 +8465,11 @@ v8-compile-cache@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.0.tgz#526492e35fc616864284700b7043e01baee09f0a"
 
+v8-compile-cache@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
+  integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
+
 validate-npm-package-license@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
@@ -8149,6 +8640,13 @@ write-file-atomic@^2.0.0, write-file-atomic@^2.1.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
+  dependencies:
+    mkdirp "^0.5.1"
 
 ws@^5.1.1, ws@^5.2.0:
   version "5.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,6 +306,7 @@ asn1.js@^4.0.0:
 asn1@0.1.11:
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.1.11.tgz#559be18376d08a4ec4dbe80877d27818639b2df7"
+  integrity sha1-VZvhg3bQik7E2+gId9J4GGObLfc=
 
 asn1@~0.2.3:
   version "0.2.3"
@@ -318,6 +319,7 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
 assert-plus@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.1.5.tgz#ee74009413002d84cec7219c6ac811812e723160"
+  integrity sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=
 
 assert@^1.1.1:
   version "1.4.1"
@@ -354,6 +356,7 @@ async@^2.1.4, async@^2.5.0:
 async@~0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -392,6 +395,7 @@ autoprefixer@^6.3.1:
 aws-sign2@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.5.0.tgz#c57103f7a17fc037f02d7c2e64b602ea223f7d63"
+  integrity sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -1062,6 +1066,11 @@ bluebird@^3.5.2:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
 
+bluebird@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de"
+  integrity sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
@@ -1073,6 +1082,7 @@ boolbase@^1.0.0, boolbase@~1.0.0:
 boom@0.4.x:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/boom/-/boom-0.4.2.tgz#7a636e9ded4efcefb19cef4947a3c67dfaee911b"
+  integrity sha1-emNune1O/O+xnO9JR6PGffrukRs=
   dependencies:
     hoek "0.9.x"
 
@@ -1648,6 +1658,7 @@ combined-stream@1.0.6, combined-stream@~1.0.5:
 combined-stream@~0.0.4:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-0.0.7.tgz#0137e657baa5a7541c57ac37ac5fc07d73b4dc1f"
+  integrity sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=
   dependencies:
     delayed-stream "0.0.5"
 
@@ -1859,6 +1870,7 @@ cross-zip@^2.1.5:
 cryptiles@0.2.x:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-0.2.2.tgz#ed91ff1f17ad13d3748288594f8a48a0d26f325c"
+  integrity sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=
   dependencies:
     boom "0.4.x"
 
@@ -2072,6 +2084,7 @@ cssstyle@^1.0.0:
 ctype@0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/ctype/-/ctype-0.5.3.tgz#82c18c2461f74114ef16c135224ad0b9144ca12f"
+  integrity sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=
 
 cuint@^0.2.2:
   version "0.2.2"
@@ -2217,6 +2230,7 @@ defined@^1.0.0:
 delayed-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-0.0.5.tgz#d4b1f43a93e8296dfe02694f4680bc37a313c73f"
+  integrity sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -3006,6 +3020,7 @@ foreach@^2.0.5:
 forever-agent@~0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.5.2.tgz#6d0e09c4921f94a27f63d3b49c5feff1ea4c5130"
+  integrity sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA=
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -3014,6 +3029,7 @@ forever-agent@~0.6.1:
 form-data@~0.1.0:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-0.1.4.tgz#91abd788aba9702b1aabfa8bc01031a2ac9e3b12"
+  integrity sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=
   dependencies:
     async "~0.9.0"
     combined-stream "~0.0.4"
@@ -3219,6 +3235,7 @@ giphy-api@2.0.1:
 giphy@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/giphy/-/giphy-0.0.4.tgz#924e1e032664bd9886a27c228ffe64cb36d27470"
+  integrity sha1-kk4eAyZkvZiGonwij/5kyzbSdHA=
   dependencies:
     request "~2.40.0"
 
@@ -3448,6 +3465,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
 hawk@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-1.1.1.tgz#87cd491f9b46e4e2aeaca335416766885d2d1ed9"
+  integrity sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=
   dependencies:
     boom "0.4.x"
     cryptiles "0.2.x"
@@ -3478,6 +3496,7 @@ hmac-drbg@^1.0.0:
 hoek@0.9.x:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-0.9.1.tgz#3d322462badf07716ea7eb85baf88079cddce505"
+  integrity sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=
 
 hoek@4.x.x:
   version "4.2.1"
@@ -3559,6 +3578,7 @@ http-errors@~1.6.2:
 http-signature@~0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-0.10.1.tgz#4fbdac132559aa8323121e540779c0a012b27e66"
+  integrity sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=
   dependencies:
     asn1 "0.1.11"
     assert-plus "^0.1.5"
@@ -3665,6 +3685,11 @@ invert-kv@^1.0.0:
 invert-kv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
+
+ip-regex@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
 is-absolute-url@^2.0.0:
   version "2.1.0"
@@ -4495,6 +4520,7 @@ json-schema@0.2.3:
 json-stringify-safe@~5.0.0, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
 json5@^0.5.1:
   version "0.5.1"
@@ -4926,6 +4952,7 @@ mime-types@^2.1.12, mime-types@~2.1.17:
 mime-types@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-1.0.2.tgz#995ae1392ab8affcbfcb2641dd054e943c0d5dce"
+  integrity sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4=
 
 mime-types@~2.1.19:
   version "2.1.20"
@@ -4945,6 +4972,7 @@ mime@^2.4.3:
 mime@~1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.11.tgz#58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10"
+  integrity sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -5141,6 +5169,7 @@ node-releases@^1.0.0-alpha.10:
 node-uuid@~1.4.0:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
+  integrity sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=
 
 nomnom@~1.6.2:
   version "1.6.2"
@@ -5268,6 +5297,7 @@ nwsapi@^2.0.7:
 oauth-sign@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.3.0.tgz#cb540f93bb2b22a7d5941691a288d60e8ea9386e"
+  integrity sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=
 
 oauth-sign@~0.8.2:
   version "0.8.2"
@@ -6316,6 +6346,11 @@ psl@^1.1.24:
   version "1.1.28"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.28.tgz#4fb6ceb08a1e2214d4fd4de0ca22dae13740bc7b"
 
+psl@^1.1.28:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.4.0.tgz#5dd26156cdb69fa1fdb8ab1991667d3f80ced7c2"
+  integrity sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==
+
 public-encrypt@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.0.tgz#39f699f3a46560dd5ebacbca693caf7c65c18cc6"
@@ -6338,9 +6373,10 @@ punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
 
-punycode@2.x.x, punycode@^2.1.0:
+punycode@2.x.x, punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
@@ -6353,6 +6389,7 @@ q@^1.1.2:
 qs@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-1.0.2.tgz#50a93e2b5af6691c31bcea5dae78ee6ea1903768"
+  integrity sha1-UKk+K1r2aRwxvOpdrnjubqGQN2g=
 
 qs@~6.5.1:
   version "6.5.1"
@@ -6765,6 +6802,7 @@ request@^2.87.0, request@^2.88.0:
 request@~2.40.0:
   version "2.40.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.40.0.tgz#4dd670f696f1e6e842e66b4b5e839301ab9beb67"
+  integrity sha1-TdZw9pbx5uhC5mtLXoOTAaub62c=
   dependencies:
     forever-agent "~0.5.0"
     json-stringify-safe "~5.0.0"
@@ -7151,6 +7189,7 @@ snapdragon@^0.8.1:
 sntp@0.2.x:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-0.2.4.tgz#fb885f18b0f3aad189f824862536bceeec750900"
+  integrity sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=
   dependencies:
     hoek "0.9.x"
 
@@ -7398,7 +7437,12 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-stringstream@~0.0.4, stringstream@~0.0.5:
+stringstream@~0.0.4:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72"
+  integrity sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==
+
+stringstream@~0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
@@ -7693,7 +7737,16 @@ topo@3.x.x:
   dependencies:
     hoek "5.x.x"
 
-tough-cookie@>=0.12.0, tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
+tough-cookie@>=0.12.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-3.0.1.tgz#9df4f57e739c26930a018184887f4adb7dca73b2"
+  integrity sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==
+  dependencies:
+    ip-regex "^2.1.0"
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
+tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
   dependencies:
@@ -7747,6 +7800,7 @@ tunnel-agent@^0.6.0:
 tunnel-agent@~0.4.0:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
+  integrity sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
Adds a GifProvider class to abstract over the Giphy API. 

Adds a Provider/Factory pattern to make it easy to get a GifProvider for the API(s) you want.

The intention is that a second GifProvider (e.g. a TenorGifProvider) can be added easily without code changes in the GifBox frontend. 