### PR TITLE
Add issue template for Bug Reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,15 +17,15 @@ A clear and concise description of what actually happened.
 A clear and concise description of what you expected to happen.
 
 **Steps to Reproduce**
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+ 1. Go to '...'
+ 2. Click on '....'
+ 3. Scroll down to '....'
+ 4. See error
 
 **Desktop/OS/version Info (please complete the following information):**
- - OS: [e.g. MacOS 10.1]
- - gifbar version: [e.g. 0.1]
- - downlaod type: [dmg or app]
+- OS: (e.g. MacOS 10.1)
+- gifbar version: (e.g. 0.1)
+- downlaod type: (dmg or app)
 
 **Additional context**
 Add any other info about the problem here. Please include screenshots if you think they will help.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report any bugs you find
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A brief, concise description of the bug.
+
+**Actual behavior**
+A clear and concise description of what actually happened.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Steps to Reproduce**
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Desktop/OS/version Info (please complete the following information):**
+ - OS: [e.g. MacOS 10.1]
+ - gifbar version: [e.g. 0.1]
+ - downlaod type: [dmg or app]
+
+**Additional context**
+Add any other info about the problem here. Please include screenshots if you think they will help.


### PR DESCRIPTION
Add an issue template for bug reports.

(This was a suggested improvement in GitHub's community insight dashboard: https://github.com/joshghent/gifbar/community .)