### PR TITLE
fix(ci): gate release-please on the preflight, not the other way round

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Runs before release-please, not after. release-please creates the tag and
+  # the draft release as part of its own step, so a check that runs later
+  # cannot prevent a bad release — it can only strand a burned version number
+  # behind a draft that never gets assets.
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - name: GIF proxy worker is reachable
+        env:
+          BASE: ${{ vars.VITE_GIF_API_BASE }}
+        run: |
+          set -euo pipefail
+          # Must match the fallback in src/lib/gif-api.js.
+          base="${BASE:-https://gifbar-api.joshghent.workers.dev}"
+          base="${base%/}"
+          echo "Checking $base/health"
+          code=$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 20 --retry 3 "$base/health" || echo 000)
+          if [ "$code" != "200" ]; then
+            echo "::error::$base/health returned $code. Deploy the worker (see worker/README.md) and set the VITE_GIF_API_BASE repository variable before releasing."
+            exit 1
+          fi
+
   release-please:
+    needs: preflight
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -39,31 +62,8 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  # An installer whose GIF backend is unreachable looks like a broken app to
-  # every user who downloads it, and a published release cannot be taken back
-  # cleanly. Verify the worker answers before spending 20 minutes building.
-  preflight:
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: GIF proxy worker is reachable
-        env:
-          BASE: ${{ vars.VITE_GIF_API_BASE }}
-        run: |
-          set -euo pipefail
-          # Must match the fallback in src/lib/gif-api.js.
-          base="${BASE:-https://gifbar-api.joshghent.workers.dev}"
-          base="${base%/}"
-          echo "Checking $base/health"
-          code=$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 20 --retry 3 "$base/health" || echo 000)
-          if [ "$code" != "200" ]; then
-            echo "::error::$base/health returned $code. Deploy the worker (see worker/README) and set the VITE_GIF_API_BASE repository variable before releasing."
-            exit 1
-          fi
-
   build:
-    needs: [release-please, preflight]
+    needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,13 @@ jobs:
   # the draft release as part of its own step, so a check that runs later
   # cannot prevent a bad release — it can only strand a burned version number
   # behind a draft that never gets assets.
+  #
+  # Only on the commit that merges a release PR. release-please cuts a release
+  # exactly then, so gating every master push instead would fail ordinary
+  # commits over a backend they do not ship, and stop release-please from
+  # maintaining its PR at all.
   preflight:
+    if: "startsWith(github.event.head_commit.message, 'chore(master): release')"
     runs-on: ubuntu-latest
     steps:
       - name: GIF proxy worker is reachable
@@ -48,6 +54,9 @@ jobs:
 
   release-please:
     needs: preflight
+    # preflight is skipped on ordinary commits; a skipped dependency would
+    # otherwise skip this job too. Run unless preflight actually failed.
+    if: always() && needs.preflight.result != 'failure' && needs.preflight.result != 'cancelled'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/worker/.gitignore
+++ b/worker/.gitignore
@@ -1,2 +1,6 @@
 node_modules/
 .wrangler/
+
+# Local secrets for `wrangler dev` — never commit
+.dev.vars
+.dev.vars.*

--- a/worker/README.md
+++ b/worker/README.md
@@ -48,6 +48,13 @@ deploy under that name the variable is optional.
 
 ## Local development
 
+Put the keys in `worker/.dev.vars` (gitignored — never commit it):
+
+```
+GIPHY_API_KEY=...
+TENOR_API_KEY=...
+```
+
 ```shell
 npx wrangler dev          # serves on http://localhost:8787
 ```


### PR DESCRIPTION
Follow-up to #271, fixing two flaws in the pipeline I added there.

## 1. The preflight ran too late to be a gate

The `preflight` job (which checks the GIF proxy Worker is live) ran **after** `release-please`. That is too late: release-please creates the tag *and* the draft GitHub release as part of its own step, so a failure afterwards cannot prevent a bad release. It can only leave a burned version number behind a draft that never receives assets — and re-running after fixing the Worker reports `release_created=false`, because the version was already cut.

Concretely: merging #272 today, with the Worker undeployed, would have stranded tag `v2.1.0`.

## 2. …but gating every push would be worse

Moving it ahead of `release-please` unconditionally would fail **every ordinary master commit** over a backend that commit doesn't ship — turning master red until the Worker is deployed, and stopping release-please from maintaining its release PR at all.

So preflight runs only on the commit that merges a release PR, which is exactly when release-please cuts a release and is identifiable from the commit subject beforehand. `release-please` then runs unless preflight actually *failed* — a skipped dependency would otherwise skip it too.

The `if` expression is quoted because the release commit subject contains a colon-space, which YAML would otherwise parse as a mapping (caught by validating the file rather than by CI).