### PR TITLE
ci: deploy the GIF proxy worker from Actions

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -1,0 +1,66 @@
+name: Deploy worker
+
+# Deploys the GIF proxy (worker/) to Cloudflare.
+#
+# Only the code deploys from here. The GIPHY and Tenor keys are set once with
+# `wrangler secret put` and live solely in Cloudflare — mirroring them into
+# GitHub secrets would widen the blast radius for keys that change maybe once
+# a year, and the whole point of the worker is to shrink where they exist.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "worker/**"
+      - ".github/workflows/worker.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-worker
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+
+      - run: npm ci
+        working-directory: worker
+
+      # The release pipeline gates on this worker being healthy, so a broken
+      # deploy blocks releases. Cheap to run the tests first.
+      - run: npm test
+        working-directory: worker
+
+      # Uses the wrangler pinned in worker/package-lock.json rather than a
+      # floating one from an action, so CI deploys the version tested above.
+      - run: npx wrangler deploy
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Verify the deployed worker answers
+        env:
+          BASE: ${{ vars.VITE_GIF_API_BASE }}
+        run: |
+          set -euo pipefail
+          base="${BASE:-https://gifbar-api.joshghent.workers.dev}"
+          base="${base%/}"
+          curl -fsS --retry 5 --retry-all-errors --max-time 20 "$base/health"
+          echo
+
+          # /health passes with no keys configured — a provider without a key is
+          # skipped rather than erroring — so check that GIFs actually come back.
+          count=$(curl -fsS --max-time 20 "$base/trending?limit=4" | jq '.gifs | length')
+          echo "trending returned $count gifs"
+          if [ "$count" -eq 0 ]; then
+            echo "::error::Worker is up but returned no GIFs. Set the provider keys: cd worker && npx wrangler secret put GIPHY_API_KEY (and TENOR_API_KEY)."
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -68,18 +68,8 @@ which holds the keys as encrypted secrets and normalizes both providers into one
 response shape. The desktop app only ever talks to that Worker. A leaked or
 rate-limited key can be rotated with `wrangler secret put` — no new release.
 
-To deploy your own:
-
-```shell
-cd worker
-npm install
-npx wrangler secret put GIPHY_API_KEY
-npx wrangler secret put TENOR_API_KEY
-npx wrangler deploy
-```
-
-Then set the `VITE_GIF_API_BASE` repository variable in GitHub Actions to the
-URL that `wrangler deploy` prints.
+The Worker deploys from CI — see [`worker/README.md`](./worker/README.md) for
+the one secret it needs and how to set the provider keys.
 
 ## Development
 
@@ -127,7 +117,8 @@ Required GitHub Actions configuration:
 | --- | --- | --- |
 | `TAURI_SIGNING_PRIVATE_KEY` | secret | signs updater artifacts (`npx tauri signer generate`) |
 | `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | secret | password for the above |
-| `VITE_GIF_API_BASE` | variable | URL of the deployed GIF proxy Worker |
+| `CLOUDFLARE_API_TOKEN` | secret | deploys the GIF proxy Worker |
+| `VITE_GIF_API_BASE` | variable | URL of the Worker — only if it is not the default |
 
 Note that CI itself needs **no** secrets, which is what keeps Dependabot's
 builds green — Dependabot events get an empty secrets context.

--- a/worker/README.md
+++ b/worker/README.md
@@ -34,17 +34,46 @@ All return `{ "gifs": [{ id, title, preview, original, source }] }`.
 
 ## Deploying
 
+CI does it. `.github/workflows/worker.yml` deploys on any push to `master`
+touching `worker/**`, and can be run by hand from the Actions tab
+(**Deploy worker** -> Run workflow).
+
+It needs one repository secret:
+
+| Secret | How to get it |
+| --- | --- |
+| `CLOUDFLARE_API_TOKEN` | Cloudflare dashboard -> My Profile -> API Tokens -> Create Token -> **Edit Cloudflare Workers** template |
+
+### The provider keys
+
+Deploying does **not** set the GIPHY and Tenor keys, and CI never sees them.
+Set them once, directly against Cloudflare:
+
 ```shell
-npm install
+cd worker && npm install
+npx wrangler login
 npx wrangler secret put GIPHY_API_KEY
 npx wrangler secret put TENOR_API_KEY
-npx wrangler deploy
 ```
 
-Then set the `VITE_GIF_API_BASE` **repository variable** in GitHub Actions to
-the URL `wrangler deploy` prints. The app falls back to
-`https://gifbar-api.joshghent.workers.dev` when the variable is unset, so if you
-deploy under that name the variable is optional.
+Or add them under the Worker's **Settings -> Variables and Secrets** in the
+Cloudflare dashboard, which avoids installing anything locally.
+
+They are deliberately not mirrored into GitHub secrets: they change maybe once
+a year, and keeping them in one place is the entire point of this worker.
+Secrets apply immediately — no redeploy needed.
+
+### Which URL
+
+The app falls back to `https://gifbar-api.joshghent.workers.dev`, so if the
+worker deploys under that name nothing else is needed. If it lands elsewhere,
+set the `VITE_GIF_API_BASE` **repository variable** to the deployed URL.
+
+### Deploying by hand
+
+```shell
+cd worker && npm install && npx wrangler deploy
+```
 
 ## Local development
 


### PR DESCRIPTION
Deploys `worker/` to Cloudflare from CI instead of from whichever laptop is nearby.

Triggers on any `master` push touching `worker/**`, and on **workflow_dispatch** — so the very first deploy can be done from the Actions tab without installing wrangler or running `wrangler login` locally.

### Setup — one secret

| Secret | Where |
| --- | --- |
| `CLOUDFLARE_API_TOKEN` | Cloudflare → My Profile → API Tokens → Create Token → **Edit Cloudflare Workers** template |

### The provider keys stay out of CI

Deploying does **not** set `GIPHY_API_KEY` / `TENOR_API_KEY`, and Actions never sees them. Set them once against Cloudflare — either `wrangler secret put`, or the Worker's **Settings → Variables and Secrets** in the dashboard if you'd rather not install anything.

Mirroring them into GitHub secrets would put the keys in two places to save a once-a-year task, which is the opposite of why the Worker exists. Secrets apply immediately, with no redeploy.

### Notes

- Runs the worker tests before deploying — the release pipeline gates on this Worker being healthy, so a bad deploy blocks releases.
- Uses the wrangler pinned in `worker/package-lock.json` (4.124.0) rather than a floating version from a third-party action, so what deploys is what was tested.
- The post-deploy check hits `/trending`, not just `/health`. A provider with no key is *skipped* rather than erroring, so `/health` returns `ok` on a Worker that cannot actually serve a GIF — the check would be meaningless otherwise. It fails with the exact `wrangler secret put` command if zero GIFs come back.