### PR TITLE
fix: correct the worker URL and make provider keys visible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           set -euo pipefail
           # Must match the fallback in src/lib/gif-api.js.
-          base="${BASE:-https://gifbar-api.joshghent.workers.dev}"
+          base="${BASE:-https://gifbar-api.ghent.workers.dev}"
           base="${base%/}"
           echo "Checking $base/health"
           code=$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 20 --retry 3 "$base/health" || echo 000)

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -51,16 +51,25 @@ jobs:
           BASE: ${{ vars.VITE_GIF_API_BASE }}
         run: |
           set -euo pipefail
-          base="${BASE:-https://gifbar-api.joshghent.workers.dev}"
+          base="${BASE:-https://gifbar-api.ghent.workers.dev}"
           base="${base%/}"
-          curl -fsS --retry 5 --retry-all-errors --max-time 20 "$base/health"
-          echo
 
-          # /health passes with no keys configured — a provider without a key is
-          # skipped rather than erroring — so check that GIFs actually come back.
+          health=$(curl -fsS --retry 5 --retry-all-errors --max-time 20 "$base/health")
+          echo "health: $health"
+
+          # /health reports a boolean per provider, so a missing or misnamed
+          # secret is visible here rather than only as a thinner grid.
+          for provider in giphy tenor; do
+            if [ "$(echo "$health" | jq -r ".providers.$provider")" != "true" ]; then
+              echo "::warning::No ${provider} key configured — that provider will be skipped. Set it in the Cloudflare dashboard under the worker's Settings → Variables and Secrets."
+            fi
+          done
+
+          # A provider with no key is skipped rather than erroring, so /health
+          # alone returns ok on a worker that cannot serve a single GIF.
           count=$(curl -fsS --max-time 20 "$base/trending?limit=4" | jq '.gifs | length')
           echo "trending returned $count gifs"
           if [ "$count" -eq 0 ]; then
-            echo "::error::Worker is up but returned no GIFs. Set the provider keys: cd worker && npx wrangler secret put GIPHY_API_KEY (and TENOR_API_KEY)."
+            echo "::error::Worker is up but returned no GIFs — neither provider key is working."
             exit 1
           fi

--- a/src/lib/gif-api.js
+++ b/src/lib/gif-api.js
@@ -4,7 +4,7 @@
 // `strings` recovers them in seconds. The Worker holds the keys as secrets,
 // normalizes both providers, and caches at the edge. See worker/.
 const API_BASE = (
-  import.meta.env.VITE_GIF_API_BASE || "https://gifbar-api.joshghent.workers.dev"
+  import.meta.env.VITE_GIF_API_BASE || "https://gifbar-api.ghent.workers.dev"
 ).replace(/\/$/, "");
 
 async function fetchGifs(path, params) {

--- a/worker/README.md
+++ b/worker/README.md
@@ -65,7 +65,7 @@ Secrets apply immediately — no redeploy needed.
 
 ### Which URL
 
-The app falls back to `https://gifbar-api.joshghent.workers.dev`, so if the
+The app falls back to `https://gifbar-api.ghent.workers.dev`, so if the
 worker deploys under that name nothing else is needed. If it lands elsewhere,
 set the `VITE_GIF_API_BASE` **repository variable** to the deployed URL.
 

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -79,9 +79,17 @@ function clampLimit(raw) {
 }
 
 // One provider being down or rate-limited should degrade the grid, not empty
-// it — so settle both and keep whichever succeeded.
+// it — so settle both and keep whichever succeeded. Log the ones that failed:
+// silently returning half a grid is indistinguishable from a working service,
+// which is exactly how a bad key goes unnoticed.
 async function gather(tasks) {
+  const names = ["giphy", "tenor"];
   const settled = await Promise.allSettled(tasks);
+  settled.forEach((r, i) => {
+    if (r.status === "rejected") {
+      console.error(`${names[i]} request failed:`, r.reason?.message ?? r.reason);
+    }
+  });
   const [giphy, tenor] = settled.map((r) =>
     r.status === "fulfilled" ? r.value : [],
   );
@@ -96,7 +104,17 @@ function withCache(c, body) {
   return c.json(body);
 }
 
-app.get("/health", (c) => c.json({ ok: true }));
+// Reports which providers have a key configured, so a missing or misnamed
+// secret is visible without reading logs. Booleans only — never key material.
+app.get("/health", (c) =>
+  c.json({
+    ok: true,
+    providers: {
+      giphy: Boolean(c.env.GIPHY_API_KEY),
+      tenor: Boolean(c.env.TENOR_API_KEY),
+    },
+  }),
+);
 
 app.get("/trending", async (c) => {
   const limit = clampLimit(c.req.query("limit"));

--- a/worker/src/index.test.js
+++ b/worker/src/index.test.js
@@ -138,6 +138,16 @@ describe("gif proxy worker", () => {
     expect(urls.some((u) => u.includes("featured"))).toBe(true);
   });
 
+  it("reports which provider keys are configured on /health", async () => {
+    const res = await app.request("/health", {}, { GIPHY_API_KEY: "giphy-test-key" });
+    const body = await res.json();
+
+    expect(body).toEqual({ ok: true, providers: { giphy: true, tenor: false } });
+    // A missing key must be visible without reading logs — that is the whole
+    // point — but the key itself must never be.
+    expect(JSON.stringify(body)).not.toContain("giphy-test-key");
+  });
+
   it("skips a provider whose key is not configured", async () => {
     bothProvidersOk();
 


### PR DESCRIPTION
## The red run

The deploy in [run 32279421032](https://github.com/joshghent/gifbar/actions/runs/32279421032) **succeeded**. Wrangler printed:

```
Deployed gifbar-api triggers
  https://gifbar-api.ghent.workers.dev
```

The post-deploy check then failed with `Could not resolve host: gifbar-api.joshghent.workers.dev`.

My fault: I guessed the workers.dev subdomain from the GitHub username when writing the fallback. It is `ghent`, not `joshghent`. Corrected in `src/lib/gif-api.js`, `worker.yml` and `release.yml`. The `VITE_GIF_API_BASE` repository variable is already set to the correct URL, so CI is unblocked either way — this makes the committed default right too, which matters because the app falls back to it when the variable is absent.

## The thing that hid underneath it

Verifying against the real URL showed the Worker is up and serving — but **only GIPHY**:

```
$ curl -s '.../trending?limit=6' | jq -r '[.gifs[].source]|group_by(.)|map({(.[0]):length})|add'
{ "giphy": 3 }
```

Tenor returns nothing on both `/trending` and `/search`, and nothing anywhere said so. `gather()` discarded the rejection reason, so a missing or invalid key was indistinguishable from a healthy service returning a slightly thinner grid. That is the failure mode this repo has been bitten by twice today already.

So:

- `gather()` logs which provider failed and why (Workers observability is on).
- `/health` now reports a boolean per provider, so a misnamed secret is diagnosable without log access. **Booleans only, never key material** — asserted in a test.
- The deploy check emits a `::warning::` naming any unconfigured provider, and still fails only when *no* GIFs come back, since one working provider is serviceable.

## Action for you

Once this merges, `/health` will tell us directly:

```bash
curl -s https://gifbar-api.ghent.workers.dev/health | jq
# {"ok":true,"providers":{"giphy":true,"tenor":false}}
```

If `tenor` is `false`, the secret is missing or misnamed — it must be exactly `TENOR_API_KEY`. If it is `true` but still no Tenor GIFs, the key is being rejected upstream and the reason will now be in the Worker logs.

Tests: 8 worker, 18 app, all green.